### PR TITLE
added change addresses to 3-of-7 CreateWallet script

### DIFF
--- a/CreateWallet.sh
+++ b/CreateWallet.sh
@@ -19,7 +19,7 @@ backup() {
 	j=1		# j is counter since this will be used inside another loop,
 	sum=0		# sum holds the sum of the base 58 values to create a 5th checksum column of seed words for yeti compatibility and easier error recovery
 	echo -e "\n\nWIF NATO Seed $i\n\n"
-	while read -n1 letter; do		# loop thru each character of seed, assign character to letter, sed command spaces digits so each is considered individually		
+	while read -n1 letter; do		# loop thru each character of seed, assign character to letter, sed command spaces digits so each is considered individually
 		num=$(( $(expr index "$base58_alphabet" "$letter") - 1))		# find index (position) of letter in base58_alphabet 1-58
 		(( sum += num ))		# increase sum by num - 1
 		echo -n ${to_nato[$num]}" "		# echos the NATO word for the letter, followed by space
@@ -29,13 +29,13 @@ backup() {
 		fi		# end if statement
 		(( j++ ))	# increment counter
 	done < <(echo -n $1) | column -t -s ' '		# inserts parameter (a seed) into the while read -n1 loop, then format while loop output into columns with space as delineator
-	
+
 	echo -e "\n\nWrite these 65 words down (case-sensitive) and Label them \"SEED $i\".\nIf you are only testing CreateWallet.sh you can skip writing these down and find yetiseed$i.txt in your home/Documents Folder.\n\nWhen you are finished press Enter."		# prompt user to hand-write
 	read -n1	# wait for any key press
 	clear		# clear terminal so user must type from paper backup
 	echo -e "Confirm you have Written Down your seed words Correctly\n\nIf you are just testing CreateWallet.sh and don't plan to use large amounts you may paste from home/Documents/yetiseed$i.txt.\n\nIf you lose access to more than 4 of your seeds your bitcoin will be permanently lost.\n\nCover up the 5th Column of your written seed words. Type all Number Words as the Numeral, otherwise type the First Letter of each word. Start on line 1, left to right and continue through all rows until done.\n\n\tLIMA    ONE     victor  echo\n\tFOXTROT romeo   THREE   ECHO\n\nWould for example be entered as:  L1veFr3E\n\nInput on one line below without spaces and when finished press Enter.\n\n"
 	read -n52 -e -p "WIF Key $i: "		# reads 52 characters of input then continues to next line
-	echo ""		# echo new line	
+	echo ""		# echo new line
 	j=0			# reset counter
 	retry=''		# empty string stored in retry, this is a flag thrown for typos
 	while read -n1 letter; do		# loop thru each letter of seed, assign to letter.
@@ -48,8 +48,8 @@ backup() {
 	if [ "$retry" == '' ]; then		# if retry is blank, say key matches and exit function
 		echo -e "WIF Key $i Matches.\n\n\nMake a Digital Backup\n\nLabel a blank CD-R \"SEED$i\", then insert it into your CD drive.\nA data CD project will open with the 3 files needed on this disc once you press Enter. Click 'Burn'.\nClose the burner software when finished.\n\nThe files xprvwallet$i, yetiseed$i and Descriptor from your home/Documents/ folder will be burned."
 		read -n1
-		brasero -d ~/Documents/xprvwallet$i ~/Documents/yetiseed$i ~/Documents/Descriptor	# launches a data project in brasero with the 3 files to burn
-		xfburn -d ~/Documents/xprvwallet$i ~/Documents/yetiseed$i ~/Documents/Descriptor 	# launches a data project in xfburn with the 3 files to burn
+		brasero -d ~/Documents/xprvwallet$i ~/Documents/yetiseed$i ~/Documents/Descriptor ~/Documents/ChangeDescriptor	# launches a data project in brasero with the 4 files to burn
+		xfburn -d ~/Documents/xprvwallet$i ~/Documents/yetiseed$i ~/Documents/Descriptor ~/Documents/ChangeDescriptor 	# launches a data project in xfburn with the 4 files to burn
 		echo -e "\n\nPlace the written seed words and \"SEED $i\" disc in a non-descript envelope.\nFor Testing with small amounts, you may use USB flash drives but these aren't durable enough for long-term storage and make a thick, conspicuous seed packet.\nPress Enter to Continue."
 		read -n1
 	else
@@ -73,24 +73,28 @@ gnome-terminal -- ./bitcoin-qt -server		# Launch the Bitcoin GUI from a second t
 read -n1
 
 # Seed Generation and Descriptor Creation
-echo -n "wsh(multi($m" > xprv_desc			# form beginning of pay-to-witness-script-hash multisig descriptor with spend threshold m signatures, save string as descriptor
+echo -n "wsh(sortedmulti($m" > xprv_desc			# form beginning of pay-to-witness-script-hash multisig descriptor with spend threshold m signatures, save string as descriptor
+echo -n "wsh(sortedmulti($m" > xprv_desc_change               # Start a descriptor for change addresses
 for (( i = 1 ; i <= $n ; i++ )); do			# loop thru idented steps n times
 	./bitcoin-cli createwallet $i			#create a wallet
 	./bitcoin-cli -rpcwallet=$i dumpwallet $i	# dump the wallet to a walletdump file, this contains xprv and seed
 	sed '6q;d' $i | tail -c112 > xprv$i		# find line 6 in file, trim line to xprv data, save as xprv
-	echo -n ",$(< xprv$i)/*" >> xprv_desc		# append ",xprv/*" to xprv_desc
+	echo -n ",$(< xprv$i)/0/*" >> xprv_desc		# append ",xprv/*" to xprv_desc
+        echo -n ",$(< xprv$i)/1/*" >> xprv_desc_change
 	grep "hdseed=1" $i | head -c52 > ~/Documents/yetiseed$i		#search for line with hdseed, trims line to WIF seed, save as yetiseed
 	done
 echo -n "))" >> xprv_desc				# append )) to close parentheses from wsh(multi( and finish descriptor
+echo -n "))" >> xprv_desc_change
 
 # Get canonical xpub descriptor form, then create and backup the Watch-only wallet
 
 # getdescriptorinfo returns the descriptor in canonical form without private keys, trim, save as descriptor
 ./bitcoin-cli getdescriptorinfo "$(< xprv_desc)" | sed '2q;d'| cut -d '"' -f4 > ~/Documents/Descriptor
+./bitcoin-cli getdescriptorinfo "$(< xprv_desc_change)" | sed '2q;d'| cut -d '"' -f4 > ~/Documents/ChangeDescriptor
 # create blank descriptor wallet pubwallet.dat, disable prv keys for Watch-Only, no passphrase, avoid address reuse true, load on start-up true
 ./bitcoin-cli createwallet "pubwallet" true true "" true true true
 # import descriptor, scan from current block, set as active descriptor
-./bitcoin-cli -rpcwallet="pubwallet" importdescriptors '[{"desc": "'$(< ~/Documents/Descriptor)'", "timestamp": "now", "active": true}]'
+./bitcoin-cli -rpcwallet="pubwallet" importdescriptors '[{"desc": "'$(< ~/Documents/ChangeDescriptor)'", "active": true, "timestamp": "now", "internal": true}, {"desc": "'$(< ~/Documents/Descriptor)'", "timestamp": "now", "active": true}]'
 # backup watch-only wallet as pubwallet.dat
 ./bitcoin-cli -rpcwallet="pubwallet" backupwallet ~/Documents/pubwallet
 
@@ -99,12 +103,14 @@ echo -n "))" >> xprv_desc				# append )) to close parentheses from wsh(multi( an
 # Get individual xpubs so they can be replaced one by one with corresponding xprv in descriptors for the n private key containing wallets and their backups
 
 for ((i = 1 ; i <= $n ; i++)); do		# loop thru indented n times
-	echo "Creating Private Wallet $i..."	
+	echo "Creating Private Wallet $i..."
 	cut -d "," -f$(( i + 1 )) < ~/Documents/Descriptor | head -c111 > xpub$i			# chop descriptor apart by commas, find each xpub starting in field 2, trim to xpub data, save as xpub
 	echo -n $(sed "s/$(< xpub$i)/$(< xprv$i)/" ~/Documents/Descriptor | cut -d "#" -f1) > desc_with_xprv$i	# replace xpub with xprv in descriptor, remove checksum, save as desc_with_xprv
+        echo -n $(sed "s/$(< xpub$i)/$(< xprv$i)/" ~/Documents/ChangeDescriptor | cut -d "#" -f1) > change_desc_with_xprv$i
 	echo -n "#$(./bitcoin-cli getdescriptorinfo "$(< desc_with_xprv$i)" | sed '3q;d' | cut -d '"' -f4)" >> desc_with_xprv$i		# call getdescriptorinfo, get line 3, cut by ", select field 4 which is checksum, append #checksum to desc_with_xprv
+        echo -n "#$(./bitcoin-cli getdescriptorinfo "$(< change_desc_with_xprv$i)" | sed '3q;d' | cut -d '"' -f4)" >> change_desc_with_xprv$i
 	./bitcoin-cli createwallet "xprvwallet$i" false true "" false true true		# create blank descriptor wallet xprvwallet, disable private keys false, no passphrase, avoid address reuse false, load on startup true
-	./bitcoin-cli -rpcwallet=xprvwallet$i importdescriptors '[{"desc": "'$(< desc_with_xprv$i)'", "timestamp": "now", "active": true}]'		# import desc_with_xprv to above wallet, scan from now, set as active descriptor in this wallet
+	./bitcoin-cli -rpcwallet=xprvwallet$i importdescriptors '[{"desc": "'$(< change_desc_with_xprv$i)'", "timestamp": "now", "active": true, "internal": true}, {"desc": "'$(< desc_with_xprv$i)'", "timestamp": "now", "active": true}]'		# import desc_with_xprv to above wallet, scan from now, set as active descriptor in this wallet
 	./bitcoin-cli -rpcwallet=xprvwallet$i backupwallet ~/Documents/xprvwallet$i	# backup wallet to xprvwallet .dat
 	backup $(< ~/Documents/yetiseed$i)	# display seed words and prompt to make a CD-R of yetiseed .txt and Descriptor.txt
 	done
@@ -117,8 +123,8 @@ read -n1
 libreoffice --writer ~/Documents/Descriptor		# launches libreoffice writer to print the descriptor
 echo -e "\n\nMake a Digital Backup\n\nA new data CD project will open with the 2 files you need to burn to 7 discs once you press enter. Click 'Burn'.\nClose the burner software when finished. Label the discs \"Watch Only.\"\n\nThe files pubwallet and Descriptor from your home/Documents/ folder will be burned.\n\n"
 read -n1
-brasero -d ~/Documents/pubwallet ~/Documents/Descriptor	# launches a data project in brasero with the 3 files to burn
-xfburn -d ~/Documents/pubwallet ~/Documents/Descriptor	# launches a data project in xfburn with the 3 files to burn
+brasero -d ~/Documents/pubwallet ~/Documents/Descriptor ~/Documents/ChangeDescriptor	# launches a data project in brasero with the 4 files to burn
+xfburn -d ~/Documents/pubwallet ~/Documents/Descriptor ~/Documents/ChangeDescriptor	# launches a data project in xfburn with the 4 files to burn
 echo -e "\nWhen you have verified all printed copies are legible, burned and labeled the discs, place one paper descriptor and one \"Watch Only\" disc into each envelope containing a handwritten seed.\nPress Any Key to continue."
 
 read -n1		# waits for any key press while user prints & burns


### PR DESCRIPTION
This commit changes the descriptor to add another component to the derivation path for the xpubs (was `m/*`, is now `m/0/*`) and adds a second descriptor with the same xpubs and a derivation path of `m/1/*`. When calling `import descriptors`, it passes both, marking the /1/ descriptor as `internal`. The effect of all of this is that the wallet now generates change addresses automatically. 

I also changed the wallet descriptor to use `sortedmulti` instead of `multi`. This means that in the future if you ever had to regenerate the descriptor from the private keys, ordering wouldn't matter (`sortedmulti` does a lexicographic sort of the XPUBs). It also means that you can import the wallet descriptor into other software like Sparrow wallet for watching or formatting transactions.

The other scripts (coin flip wallet, custom wallet) have not been updated, nor have the docs. Planning on getting to those when I have time, but if anyone wants to play with this change, here it is!

Also note that this breaks compatibility with the yeticold restore functionality. Maybe I should copy and rename this script to keep one that works with yeti, and one that is new-and-improved. Thoughts?